### PR TITLE
update istio access log format for +1.9 proxies

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -13,6 +13,8 @@ type AccessLog struct {
 	BytesReceived string `mapstructure:"bytes_received" json:"bytes_received,omitempty"`
 	// BytesSent as part of the request body %BYTES_SENT%
 	BytesSent string `mapstructure:"bytes_sent" json:"bytes_sent,omitempty"`
+	// ConnectionTerminationDetails provide additional information about why the connection was terminated by Envoy %CONNECTION_TERMINATION_DETAILS%
+	ConnectionTerminationDetails string `mapstructure:"termination_details" json:"connection_termination_details,omitempty"`
 	// Duration of the request %DURATION%
 	Duration string `mapstructure:"duration" json:"duration,omitempty"`
 	// ForwardedFor is the X-Forwarded-For header value %REQ(FORWARDED-FOR)%
@@ -45,6 +47,8 @@ type AccessLog struct {
 	DownstreamRemote string `mapstructure:"downstream_remote" json:"downstream_remote,omitempty"`
 	// RequestedServer is the String value set on ssl connection socket for Server Name Indication (SNI) %REQUESTED_SERVER_NAME%
 	RequestedServer string `mapstructure:"requested_server" json:"requested_server,omitempty"`
+	// RersponseCodeDetails provides additional information about the response code %RESPONSE_CODE_DETAILS%
+	ResponseCodeDetails string `mapstructure:"response_details" json:"response_code_details,omitempty"`
 	// RouteName is the name of the VirtualService route which matched this request %ROUTE_NAME%
 	RouteName string `mapstructure:"route_name" json:"route_name,omitempty"`
 	// UpstreamFailureReason is the upstream transport failure reason %UPSTREAM_TRANSPORT_FAILURE_REASON%
@@ -55,8 +59,6 @@ type AccessLog struct {
 	UriPath string `mapstructure:"uri_path" json:"uri_path,omitempty"`
 	// UserAgent is the request User Agent field %REQ(USER-AGENT)%"
 	UserAgent string `mapstructure:"user_agent" json:"user_agent,omitempty"`
-	// MixerStatus is the dynamic metadata information for the mixer status %DYNAMIC_METADATA(mixer:status)%
-	MixerStatus string `mapstructure:"mixer_status" json:"mixer_status,omitempty"`
 	// OriginalMessage is the original raw log line.
 	OriginalMessage string `json:"original_message,omitempty"`
 	// ParseError provides a string value if a parse error occured.
@@ -69,8 +71,8 @@ type Pattern string
 const (
 	// EnvoyAccessLogsPattern is the default envoy access log format
 	EnvoyAccessLogsPattern Pattern = `\[%{TIMESTAMP_ISO8601:timestamp}\] \"%{DATA:method} (?:%{URIPATH:uri_path}(?:%{URIPARAM:uri_param})?|%{DATA}) %{DATA:protocol}\" %{NUMBER:status_code} %{DATA:response_flags} %{NUMBER:bytes_received} %{NUMBER:bytes_sent} %{NUMBER:duration} (?:%{NUMBER:upstream_service_time}|%{DATA:tcp_service_time}) \"%{DATA:forwarded_for}\" \"%{DATA:user_agent}\" \"%{DATA:request_id}\" \"%{DATA:authority}\" \"%{DATA:upstream_service}\"`
-	// IstioProxyAccessLogsPattern is the default istio-proxy (envoy) access log format in Istio Service Mesh (matching Istio 1.1, 1.2, and 1.3+ formats)
-	IstioProxyAccessLogsPattern Pattern = `\[%{TIMESTAMP_ISO8601:timestamp}\] \"%{DATA:method} (?:(?:%{URIPATH:uri_path}(?:%{URIPARAM:uri_param})?)|%{DATA}) %{DATA:protocol}\" %{NUMBER:status_code} %{DATA:response_flags} \"%{DATA:mixer_status}\"(?: \"%{DATA:upstream_failure_reason}\")? %{NUMBER:bytes_received} %{NUMBER:bytes_sent} %{NUMBER:duration} (?:%{NUMBER:upstream_service_time}|%{DATA:tcp_service_time}) \"%{DATA:forwarded_for}\" \"%{DATA:user_agent}\" \"%{DATA:request_id}\" \"%{DATA:authority}\" \"%{DATA:upstream_service}\" %{DATA:upstream_cluster} %{DATA:upstream_local} %{DATA:downstream_local} %{DATA:downstream_remote} %{DATA:requested_server}(?: %{DATA:route_name})?$`
+	// IstioProxyAccessLogsPattern is the default istio-proxy (envoy) access log format in Istio Service Mesh (matching Istio 1.9+ formats)
+	IstioProxyAccessLogsPattern Pattern = `\[%{TIMESTAMP_ISO8601:timestamp}\] \"%{DATA:method} (?:(?:%{URIPATH:uri_path}(?:%{URIPARAM:uri_param})?)|%{DATA}) %{DATA:protocol}\" %{NUMBER:status_code} %{DATA:response_flags} %{DATA:response_details} %{DATA:termination_details} \"%{DATA:upstream_failure_reason}\" %{NUMBER:bytes_received} %{NUMBER:bytes_sent} %{NUMBER:duration} (?:%{NUMBER:upstream_service_time}|%{DATA:tcp_service_time}) \"%{DATA:forwarded_for}\" \"%{DATA:user_agent}\" \"%{DATA:request_id}\" \"%{DATA:authority}\" \"%{DATA:upstream_service}\" %{DATA:upstream_cluster} %{DATA:upstream_local} %{DATA:downstream_local} %{DATA:downstream_remote} %{DATA:requested_server}(?: %{DATA:route_name})?$`
 )
 
 // Parser implements the parsing logic


### PR DESCRIPTION
Default log format was updated in Istio 1.9 (PR https://github.com/istio/istio/pull/27903) to add `%RESPONSE_CODE_DETAIL%` and `%CONNECTION_TERMINATION_DETAILS%`

Samples Istio access logs for these fields set: 
```
[2020-10-29T03:22:16.126Z] "GET /headers HTTP/1.1" 200 - via_upstream - "-" 0 547 5 4 "-" "curl/7.73.0-DEV" "24e58e43-e576-9048-829b-02e3f3da16f0" "httpbin:8000" "127.0.0.1:80" inbound|8000|| 127.0.0.1:51680 172.17.0.7:80 172.17.0.6:59022 outbound_.8000_._.httpbin.foo.svc.cluster.local default
{
  "authority": "httpbin:8000",
  "bytes_received": "0",
  "bytes_sent": "547",
  "connection_termination_details": "-",
  "duration": "5",
  "forwarded_for": "-",
  "method": "GET",
  "protocol": "HTTP/1.1",
  "request_id": "24e58e43-e576-9048-829b-02e3f3da16f0",
  "response_flags": "-",
  "status_code": "200",
  "timestamp": "2020-10-29T03:22:16.126Z",
  "upstream_service": "127.0.0.1:80",
  "upstream_service_time": "4",
  "upstream_cluster": "inbound|8000||",
  "upstream_local": "127.0.0.1:51680",
  "downstream_local": "172.17.0.7:80",
  "downstream_remote": "172.17.0.6:59022",
  "requested_server": "outbound_.8000_._.httpbin.foo.svc.cluster.local",
  "response_code_details": "via_upstream",
  "route_name": "default",
  "upstream_failure_reason": "-",
  "uri_path": "/headers",
  "user_agent": "curl/7.73.0-DEV",
  "original_message": "[2020-10-29T03:22:16.126Z] \"GET /headers HTTP/1.1\" 200 - via_upstream - \"-\" 0 547 5 4 \"-\" \"curl/7.73.0-DEV\" \"24e58e43-e576-9048-829b-02e3f3da16f0\" \"httpbin:8000\" \"127.0.0.1:80\" inbound|8000|| 127.0.0.1:51680 172.17.0.7:80 172.17.0.6:59022 outbound_.8000_._.httpbin.foo.svc.cluster.local default"
}

[2020-10-29T03:23:33.415Z] "- - -" 0 NR filter_chain_not_found - "-" 0 0 0 - "-" "-" "-" "-" "-" - - 172.17.0.7:80 172.17.0.6:59800 - -
{
  "authority": "-",
  "bytes_received": "0",
  "bytes_sent": "0",
  "connection_termination_details": "-",
  "duration": "0",
  "forwarded_for": "-",
  "method": "-",
  "protocol": "-",
  "request_id": "-",
  "response_flags": "NR",
  "status_code": "0",
  "tcp_service_time": "-",
  "timestamp": "2020-10-29T03:23:33.415Z",
  "upstream_service": "-",
  "upstream_cluster": "-",
  "upstream_local": "-",
  "downstream_local": "172.17.0.7:80",
  "downstream_remote": "172.17.0.6:59800",
  "requested_server": "-",
  "response_code_details": "filter_chain_not_found",
  "route_name": "-",
  "upstream_failure_reason": "-",
  "user_agent": "-",
  "original_message": "[2020-10-29T03:23:33.415Z] \"- - -\" 0 NR filter_chain_not_found - \"-\" 0 0 0 - \"-\" \"-\" \"-\" \"-\" \"-\" - - 172.17.0.7:80 172.17.0.6:59800 - -"
}

[2020-10-29T03:24:13.520Z] "- - HTTP/1.1" 400 DPE http1.codec_error - "-" 0 11 0 - "-" "-" "-" "-" "-" - - 172.17.0.7:80 172.17.0.6:60214 - -
{
  "authority": "-",
  "bytes_received": "0",
  "bytes_sent": "11",
  "connection_termination_details": "-",
  "duration": "0",
  "forwarded_for": "-",
  "method": "-",
  "protocol": "HTTP/1.1",
  "request_id": "-",
  "response_flags": "DPE",
  "status_code": "400",
  "tcp_service_time": "-",
  "timestamp": "2020-10-29T03:24:13.520Z",
  "upstream_service": "-",
  "upstream_cluster": "-",
  "upstream_local": "-",
  "downstream_local": "172.17.0.7:80",
  "downstream_remote": "172.17.0.6:60214",
  "requested_server": "-",
  "response_code_details": "http1.codec_error",
  "route_name": "-",
  "upstream_failure_reason": "-",
  "user_agent": "-",
  "original_message": "[2020-10-29T03:24:13.520Z] \"- - HTTP/1.1\" 400 DPE http1.codec_error - \"-\" 0 11 0 - \"-\" \"-\" \"-\" \"-\" \"-\" - - 172.17.0.7:80 172.17.0.6:60214 - -"
}

[2020-10-29T03:25:20.162Z] "GET /headers HTTP/1.1" 403 - rbac_access_denied_matched_policy[none] - "-" 0 19 0 - "-" "curl/7.73.0-DEV" "07541777-6ee2-908f-a78b-867fe257ac80" "httpbin:8000" "-" - - 172.17.0.7:80 172.17.0.6:60898 outbound_.8000_._.httpbin.foo.svc.cluster.local -
{
  "authority": "httpbin:8000",
  "bytes_received": "0",
  "bytes_sent": "19",
  "connection_termination_details": "-",
  "duration": "0",
  "forwarded_for": "-",
  "method": "GET",
  "protocol": "HTTP/1.1",
  "request_id": "07541777-6ee2-908f-a78b-867fe257ac80",
  "response_flags": "-",
  "status_code": "403",
  "tcp_service_time": "-",
  "timestamp": "2020-10-29T03:25:20.162Z",
  "upstream_service": "-",
  "upstream_cluster": "-",
  "upstream_local": "-",
  "downstream_local": "172.17.0.7:80",
  "downstream_remote": "172.17.0.6:60898",
  "requested_server": "outbound_.8000_._.httpbin.foo.svc.cluster.local",
  "response_code_details": "rbac_access_denied_matched_policy[none]",
  "route_name": "-",
  "upstream_failure_reason": "-",
  "uri_path": "/headers",
  "user_agent": "curl/7.73.0-DEV",
  "original_message": "[2020-10-29T03:25:20.162Z] \"GET /headers HTTP/1.1\" 403 - rbac_access_denied_matched_policy[none] - \"-\" 0 19 0 - \"-\" \"curl/7.73.0-DEV\" \"07541777-6ee2-908f-a78b-867fe257ac80\" \"httpbin:8000\" \"-\" - - 172.17.0.7:80 172.17.0.6:60898 outbound_.8000_._.httpbin.foo.svc.cluster.local -"
}

[2020-10-29T03:26:11.561Z] "GET /headers HTTP/1.1" 403 - rbac_access_denied_matched_policy[ns[foo]-policy[httpbin]-rule[0]] - "-" 0 19 0 - "-" "curl/7.73.0-DEV" "090a1897-d696-99b1-90f0-2673113ba258" "httpbin:8000" "-" - - 172.17.0.7:80 172.17.0.6:33204 outbound_.8000_._.httpbin.foo.svc.cluster.local -
{
  "authority": "httpbin:8000",
  "bytes_received": "0",
  "bytes_sent": "19",
  "connection_termination_details": "-",
  "duration": "0",
  "forwarded_for": "-",
  "method": "GET",
  "protocol": "HTTP/1.1",
  "request_id": "090a1897-d696-99b1-90f0-2673113ba258",
  "response_flags": "-",
  "status_code": "403",
  "tcp_service_time": "-",
  "timestamp": "2020-10-29T03:26:11.561Z",
  "upstream_service": "-",
  "upstream_cluster": "-",
  "upstream_local": "-",
  "downstream_local": "172.17.0.7:80",
  "downstream_remote": "172.17.0.6:33204",
  "requested_server": "outbound_.8000_._.httpbin.foo.svc.cluster.local",
  "response_code_details": "rbac_access_denied_matched_policy[ns[foo]-policy[httpbin]-rule[0]]",
  "route_name": "-",
  "upstream_failure_reason": "-",
  "uri_path": "/headers",
  "user_agent": "curl/7.73.0-DEV",
  "original_message": "[2020-10-29T03:26:11.561Z] \"GET /headers HTTP/1.1\" 403 - rbac_access_denied_matched_policy[ns[foo]-policy[httpbin]-rule[0]] - \"-\" 0 19 0 - \"-\" \"curl/7.73.0-DEV\" \"090a1897-d696-99b1-90f0-2673113ba258\" \"httpbin:8000\" \"-\" - - 172.17.0.7:80 172.17.0.6:33204 outbound_.8000_._.httpbin.foo.svc.cluster.local -"
}

[2020-10-29T03:28:26.690Z] "- - -" 0 - - rbac_access_denied_matched_policy[ns[foo]-policy[httpbin]-rule[0]] "-" 761 701 5 - "-" "-" "-" "-" "127.0.0.1:80" inbound|8000|| 127.0.0.1:55464 172.17.0.7:80 172.17.0.6:34574 outbound_.8000_._.httpbin.foo.svc.cluster.local -
{
  "authority": "-",
  "bytes_received": "761",
  "bytes_sent": "701",
  "connection_termination_details": "rbac_access_denied_matched_policy[ns[foo]-policy[httpbin]-rule[0]]",
  "duration": "5",
  "forwarded_for": "-",
  "method": "-",
  "protocol": "-",
  "request_id": "-",
  "response_flags": "-",
  "status_code": "0",
  "tcp_service_time": "-",
  "timestamp": "2020-10-29T03:28:26.690Z",
  "upstream_service": "127.0.0.1:80",
  "upstream_cluster": "inbound|8000||",
  "upstream_local": "127.0.0.1:55464",
  "downstream_local": "172.17.0.7:80",
  "downstream_remote": "172.17.0.6:34574",
  "requested_server": "outbound_.8000_._.httpbin.foo.svc.cluster.local",
  "response_code_details": "-",
  "route_name": "-",
  "upstream_failure_reason": "-",
  "user_agent": "-",
  "original_message": "[2020-10-29T03:28:26.690Z] \"- - -\" 0 - - rbac_access_denied_matched_policy[ns[foo]-policy[httpbin]-rule[0]] \"-\" 761 701 5 - \"-\" \"-\" \"-\" \"-\" \"127.0.0.1:80\" inbound|8000|| 127.0.0.1:55464 172.17.0.7:80 172.17.0.6:34574 outbound_.8000_._.httpbin.foo.svc.cluster.local -"
}

```
